### PR TITLE
Feature output

### DIFF
--- a/digitizer/forms.py
+++ b/digitizer/forms.py
@@ -202,7 +202,7 @@ class IsothermMultiComponentForm(IsothermSingleComponentForm):  # pylint:disable
         self.inp_concentration_units = pw.AutocompleteInput(
             name='Concentration Units',
             options=QUANTITIES['concentration_units']['names'],
-            placeholder='mmol/g',
+            placeholder='Molarity (mol/l)',
             case_sensitive=False,
             disabled=True)
 


### PR DESCRIPTION
Updates / Corrections in this PR:

1. Corrects 'measurement_type' key to 'category'
1. Adds composition/concentration descriptors (even if unimportant or null) to single-component isotherm output. One could reasonably argue that the 'concentrationUnits' key could be added in postprocessing. But the composition descriptor is a necessity, as the output JSON contains composition in the 'isotherm_data' block even for single-component isotherms.
1. Adds a function that performs point corrections on the output JSON, to deal with inconsistencies between the autofill/dropdown menus and key values expected by NIST ISODB. This is a bit 'hacky' at present, as the transforms are very specific. The better solution is for the ISODB API to output the mapping between the various descriptors and the more descriptive menu items and then use pointers to perform the transforms in a generic fashion. (This can be done, I just have to clear time to straighten out the SQL queries and update the php code for the API.) *I am definitely open to revisions on this.*