### PR TITLE
feature: added isotherm JSON files as candidates for testing the load…

### DIFF
--- a/tests/static/concentration.json
+++ b/tests/static/concentration.json
@@ -1,0 +1,327 @@
+{
+    "DOI": "10.1007/s10450-020-00253-0",
+    "adsorbates": [
+        {
+            "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+            "name": "Methane"
+        }
+    ],
+    "adsorbent": {
+        "hashkey": "NIST-MATDB-898edd41ca15e03f0e003dd2448f1e5d",
+        "name": "NIST RM-8850"
+    },
+    "adsorptionUnits": "mmol/g",
+    "articleSource": "Figure S6",
+    "associated_content": [
+        null
+    ],
+    "category": "exp",
+    "compositionType": "concentration",
+    "concentrationUnits": "Molarity (mol/l)",
+    "date": "2020-09-09",
+    "digitizer": "NIST FACT Lab",
+    "filename": "10.1007s10450-020-00253-0.DS01.Aliquot1.Isotherm1",
+    "isotherm_data": [
+        {
+            "pressure": 0.03362024,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 0.11270688,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 0.11270688
+        },
+        {
+            "pressure": 0.08608975,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 0.31327451,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 0.31327451
+        },
+        {
+            "pressure": 0.15332591,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 0.55895366,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 0.55895366
+        },
+        {
+            "pressure": 0.46870088,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 1.54686033,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 1.54686033
+        },
+        {
+            "pressure": 0.72746779,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 2.15368729,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 2.15368729
+        },
+        {
+            "pressure": 0.92712632,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 2.5157927,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 2.5157927
+        },
+        {
+            "pressure": 1.07506431,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 2.73934038,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 2.73934038
+        },
+        {
+            "pressure": 1.21080763,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 2.9156223,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 2.9156223
+        },
+        {
+            "pressure": 1.40978577,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 3.1327809,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 3.1327809
+        },
+        {
+            "pressure": 1.61057213,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 3.31352207,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 3.31352207
+        },
+        {
+            "pressure": 1.80789726,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 3.46258196,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 3.46258196
+        },
+        {
+            "pressure": 2.00828373,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 3.59151034,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 3.59151034
+        },
+        {
+            "pressure": 2.20699332,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 3.69978953,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 3.69978953
+        },
+        {
+            "pressure": 2.40949524,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 3.79539594,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 3.79539594
+        },
+        {
+            "pressure": 2.60590135,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 3.87534175,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 3.87534175
+        },
+        {
+            "pressure": 2.80855855,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 3.94688405,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 3.94688405
+        },
+        {
+            "pressure": 3.00958351,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.00769019,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.00769019
+        },
+        {
+            "pressure": 3.45024921,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.11443628,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.11443628
+        },
+        {
+            "pressure": 3.9048642,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.19419317,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.19419317
+        },
+        {
+            "pressure": 4.35044134,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.25234213,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.25234213
+        },
+        {
+            "pressure": 4.79847717,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.29152116,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.29152116
+        },
+        {
+            "pressure": 5.24724124,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.31773156,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.31773156
+        },
+        {
+            "pressure": 5.70059431,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.33362415,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.33362415
+        },
+        {
+            "pressure": 6.14138905,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.33511572,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.33511572
+        },
+        {
+            "pressure": 6.5871968,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.32510135,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.32510135
+        },
+        {
+            "pressure": 7.04147556,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.30801953,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.30801953
+        },
+        {
+            "pressure": 7.49369286,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.27961068,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.27961068
+        }
+    ],
+    "isotherm_type": "excess",
+    "pressureUnits": "MPa",
+    "tabular_data": true,
+    "temperature": 298
+}

--- a/tests/static/experimental_withkeys.json
+++ b/tests/static/experimental_withkeys.json
@@ -1,0 +1,327 @@
+{
+    "DOI": "10.1007/s10450-020-00253-0",
+    "adsorbates": [
+        {
+            "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+            "name": "Methane"
+        }
+    ],
+    "adsorbent": {
+        "hashkey": "NIST-MATDB-898edd41ca15e03f0e003dd2448f1e5d",
+        "name": "NIST RM-8850"
+    },
+    "adsorptionUnits": "mmol/g",
+    "articleSource": "Figure S6",
+    "associated_content": [
+        null
+    ],
+    "category": "exp",
+    "compositionType": "molefraction",
+    "concentrationUnits": "",
+    "date": "2020-09-09",
+    "digitizer": "NIST FACT Lab",
+    "filename": "10.1007s10450-020-00253-0.DS01.Aliquot1.Isotherm1",
+    "isotherm_data": [
+        {
+            "pressure": 0.03362024,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 0.11270688,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 0.11270688
+        },
+        {
+            "pressure": 0.08608975,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 0.31327451,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 0.31327451
+        },
+        {
+            "pressure": 0.15332591,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 0.55895366,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 0.55895366
+        },
+        {
+            "pressure": 0.46870088,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 1.54686033,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 1.54686033
+        },
+        {
+            "pressure": 0.72746779,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 2.15368729,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 2.15368729
+        },
+        {
+            "pressure": 0.92712632,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 2.5157927,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 2.5157927
+        },
+        {
+            "pressure": 1.07506431,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 2.73934038,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 2.73934038
+        },
+        {
+            "pressure": 1.21080763,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 2.9156223,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 2.9156223
+        },
+        {
+            "pressure": 1.40978577,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 3.1327809,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 3.1327809
+        },
+        {
+            "pressure": 1.61057213,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 3.31352207,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 3.31352207
+        },
+        {
+            "pressure": 1.80789726,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 3.46258196,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 3.46258196
+        },
+        {
+            "pressure": 2.00828373,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 3.59151034,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 3.59151034
+        },
+        {
+            "pressure": 2.20699332,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 3.69978953,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 3.69978953
+        },
+        {
+            "pressure": 2.40949524,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 3.79539594,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 3.79539594
+        },
+        {
+            "pressure": 2.60590135,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 3.87534175,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 3.87534175
+        },
+        {
+            "pressure": 2.80855855,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 3.94688405,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 3.94688405
+        },
+        {
+            "pressure": 3.00958351,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.00769019,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.00769019
+        },
+        {
+            "pressure": 3.45024921,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.11443628,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.11443628
+        },
+        {
+            "pressure": 3.9048642,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.19419317,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.19419317
+        },
+        {
+            "pressure": 4.35044134,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.25234213,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.25234213
+        },
+        {
+            "pressure": 4.79847717,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.29152116,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.29152116
+        },
+        {
+            "pressure": 5.24724124,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.31773156,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.31773156
+        },
+        {
+            "pressure": 5.70059431,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.33362415,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.33362415
+        },
+        {
+            "pressure": 6.14138905,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.33511572,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.33511572
+        },
+        {
+            "pressure": 6.5871968,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.32510135,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.32510135
+        },
+        {
+            "pressure": 7.04147556,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.30801953,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.30801953
+        },
+        {
+            "pressure": 7.49369286,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.27961068,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.27961068
+        }
+    ],
+    "isotherm_type": "excess",
+    "pressureUnits": "MPa",
+    "tabular_data": true,
+    "temperature": 298
+}

--- a/tests/static/experimental_withnames.json
+++ b/tests/static/experimental_withnames.json
@@ -1,0 +1,325 @@
+{
+    "DOI": "10.1007/s10450-020-00253-0",
+    "adsorbates": [
+        {
+            "name": "Methane"
+        }
+    ],
+    "adsorbent": {
+        "name": "NIST RM-8850"
+    },
+    "adsorptionUnits": "mmol/g",
+    "articleSource": "Figure S6",
+    "associated_content": [
+        null
+    ],
+    "category": "exp",
+    "compositionType": "molefraction",
+    "concentrationUnits": "",
+    "date": "2020-09-09",
+    "digitizer": "NIST FACT Lab",
+    "filename": "10.1007s10450-020-00253-0.DS01.Aliquot1.Isotherm1",
+    "isotherm_data": [
+        {
+            "pressure": 0.03362024,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 0.11270688,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 0.11270688
+        },
+        {
+            "pressure": 0.08608975,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 0.31327451,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 0.31327451
+        },
+        {
+            "pressure": 0.15332591,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 0.55895366,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 0.55895366
+        },
+        {
+            "pressure": 0.46870088,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 1.54686033,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 1.54686033
+        },
+        {
+            "pressure": 0.72746779,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 2.15368729,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 2.15368729
+        },
+        {
+            "pressure": 0.92712632,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 2.5157927,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 2.5157927
+        },
+        {
+            "pressure": 1.07506431,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 2.73934038,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 2.73934038
+        },
+        {
+            "pressure": 1.21080763,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 2.9156223,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 2.9156223
+        },
+        {
+            "pressure": 1.40978577,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 3.1327809,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 3.1327809
+        },
+        {
+            "pressure": 1.61057213,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 3.31352207,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 3.31352207
+        },
+        {
+            "pressure": 1.80789726,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 3.46258196,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 3.46258196
+        },
+        {
+            "pressure": 2.00828373,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 3.59151034,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 3.59151034
+        },
+        {
+            "pressure": 2.20699332,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 3.69978953,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 3.69978953
+        },
+        {
+            "pressure": 2.40949524,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 3.79539594,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 3.79539594
+        },
+        {
+            "pressure": 2.60590135,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 3.87534175,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 3.87534175
+        },
+        {
+            "pressure": 2.80855855,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 3.94688405,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 3.94688405
+        },
+        {
+            "pressure": 3.00958351,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.00769019,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.00769019
+        },
+        {
+            "pressure": 3.45024921,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.11443628,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.11443628
+        },
+        {
+            "pressure": 3.9048642,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.19419317,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.19419317
+        },
+        {
+            "pressure": 4.35044134,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.25234213,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.25234213
+        },
+        {
+            "pressure": 4.79847717,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.29152116,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.29152116
+        },
+        {
+            "pressure": 5.24724124,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.31773156,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.31773156
+        },
+        {
+            "pressure": 5.70059431,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.33362415,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.33362415
+        },
+        {
+            "pressure": 6.14138905,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.33511572,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.33511572
+        },
+        {
+            "pressure": 6.5871968,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.32510135,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.32510135
+        },
+        {
+            "pressure": 7.04147556,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.30801953,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.30801953
+        },
+        {
+            "pressure": 7.49369286,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 4.27961068,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 4.27961068
+        }
+    ],
+    "isotherm_type": "excess",
+    "pressureUnits": "MPa",
+    "tabular_data": true,
+    "temperature": 298
+}

--- a/tests/static/quaternary.json
+++ b/tests/static/quaternary.json
@@ -1,0 +1,461 @@
+{
+    "DOI": "10.1021/la034766z",
+    "adsorbates": [
+        {
+            "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+            "name": "Methane"
+        },
+        {
+            "InChIKey": "OTMSDBZUPAUEDD-UHFFFAOYSA-N",
+            "name": "Ethane"
+        },
+        {
+            "InChIKey": "ATUOYWHBWRKTHZ-UHFFFAOYSA-N",
+            "name": "N-propane"
+        },
+        {
+            "InChIKey": "IJDNQMDRQITEOD-UHFFFAOYSA-N",
+            "name": "N-Butane"
+        }
+    ],
+    "adsorbent": {
+        "hashkey": "NIST-MATDB-5d0728ebc1e0053aa120288307a704c8",
+        "name": "Silicalite MFI"
+    },
+    "adsorptionUnits": "mmol/g",
+    "articleSource": "Figure 6",
+    "compositionType": "molefraction",
+    "date": "2020-09-10",
+    "digitizer": "Daniel W. Siderius",
+    "filename": "10.1021La034766z.Isotherm9",
+    "isotherm_data": [
+        {
+            "pressure": 4e-06,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 0.0,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "OTMSDBZUPAUEDD-UHFFFAOYSA-N",
+                    "adsorption": 0.0033,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "ATUOYWHBWRKTHZ-UHFFFAOYSA-N",
+                    "adsorption": 0.0,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "IJDNQMDRQITEOD-UHFFFAOYSA-N",
+                    "adsorption": 0.0,
+                    "composition": 0.25
+                }
+            ]
+        },
+        {
+            "pressure": 4.072e-05,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 0.0,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "OTMSDBZUPAUEDD-UHFFFAOYSA-N",
+                    "adsorption": 0.0033,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "ATUOYWHBWRKTHZ-UHFFFAOYSA-N",
+                    "adsorption": 0.0115,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "IJDNQMDRQITEOD-UHFFFAOYSA-N",
+                    "adsorption": 0.0115,
+                    "composition": 0.25
+                }
+            ]
+        },
+        {
+            "pressure": 0.00012462,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 0.0,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "OTMSDBZUPAUEDD-UHFFFAOYSA-N",
+                    "adsorption": 0.0016,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "ATUOYWHBWRKTHZ-UHFFFAOYSA-N",
+                    "adsorption": 0.0328,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "IJDNQMDRQITEOD-UHFFFAOYSA-N",
+                    "adsorption": 0.0328,
+                    "composition": 0.25
+                }
+            ]
+        },
+        {
+            "pressure": 0.00030242,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 0.0016,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "OTMSDBZUPAUEDD-UHFFFAOYSA-N",
+                    "adsorption": 0.0033,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "ATUOYWHBWRKTHZ-UHFFFAOYSA-N",
+                    "adsorption": 0.0689,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "IJDNQMDRQITEOD-UHFFFAOYSA-N",
+                    "adsorption": 0.0689,
+                    "composition": 0.25
+                }
+            ]
+        },
+        {
+            "pressure": 0.0011954,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 0.0,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "OTMSDBZUPAUEDD-UHFFFAOYSA-N",
+                    "adsorption": 0.0049,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "ATUOYWHBWRKTHZ-UHFFFAOYSA-N",
+                    "adsorption": 0.2445,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "IJDNQMDRQITEOD-UHFFFAOYSA-N",
+                    "adsorption": 0.2445,
+                    "composition": 0.25
+                }
+            ]
+        },
+        {
+            "pressure": 0.0029884,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 0.0,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "OTMSDBZUPAUEDD-UHFFFAOYSA-N",
+                    "adsorption": 0.0115,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "ATUOYWHBWRKTHZ-UHFFFAOYSA-N",
+                    "adsorption": 0.5433,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "IJDNQMDRQITEOD-UHFFFAOYSA-N",
+                    "adsorption": 0.5433,
+                    "composition": 0.25
+                }
+            ]
+        },
+        {
+            "pressure": 0.030242,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 0.0016,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "OTMSDBZUPAUEDD-UHFFFAOYSA-N",
+                    "adsorption": 0.0197,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "ATUOYWHBWRKTHZ-UHFFFAOYSA-N",
+                    "adsorption": 1.1817,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "IJDNQMDRQITEOD-UHFFFAOYSA-N",
+                    "adsorption": 1.1817,
+                    "composition": 0.25
+                }
+            ]
+        },
+        {
+            "pressure": 0.30063,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 0.0066,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "OTMSDBZUPAUEDD-UHFFFAOYSA-N",
+                    "adsorption": 0.0295,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "ATUOYWHBWRKTHZ-UHFFFAOYSA-N",
+                    "adsorption": 1.354,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "IJDNQMDRQITEOD-UHFFFAOYSA-N",
+                    "adsorption": 1.354,
+                    "composition": 0.25
+                }
+            ]
+        },
+        {
+            "pressure": 3.0242,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 0.0115,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "OTMSDBZUPAUEDD-UHFFFAOYSA-N",
+                    "adsorption": 0.0558,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "ATUOYWHBWRKTHZ-UHFFFAOYSA-N",
+                    "adsorption": 1.3524,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "IJDNQMDRQITEOD-UHFFFAOYSA-N",
+                    "adsorption": 1.3524,
+                    "composition": 0.25
+                }
+            ]
+        },
+        {
+            "pressure": 3.5938,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 0.0131,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "OTMSDBZUPAUEDD-UHFFFAOYSA-N",
+                    "adsorption": 0.0574,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "ATUOYWHBWRKTHZ-UHFFFAOYSA-N",
+                    "adsorption": 1.359,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "IJDNQMDRQITEOD-UHFFFAOYSA-N",
+                    "adsorption": 1.359,
+                    "composition": 0.25
+                }
+            ]
+        },
+        {
+            "pressure": 30.063000000000002,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 0.023,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "OTMSDBZUPAUEDD-UHFFFAOYSA-N",
+                    "adsorption": 0.1231,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "ATUOYWHBWRKTHZ-UHFFFAOYSA-N",
+                    "adsorption": 1.2671,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "IJDNQMDRQITEOD-UHFFFAOYSA-N",
+                    "adsorption": 1.2671,
+                    "composition": 0.25
+                }
+            ]
+        },
+        {
+            "pressure": 293.56,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 0.041,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "OTMSDBZUPAUEDD-UHFFFAOYSA-N",
+                    "adsorption": 0.2166,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "ATUOYWHBWRKTHZ-UHFFFAOYSA-N",
+                    "adsorption": 1.139,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "IJDNQMDRQITEOD-UHFFFAOYSA-N",
+                    "adsorption": 1.139,
+                    "composition": 0.25
+                }
+            ]
+        },
+        {
+            "pressure": 3006.3,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 0.1198,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "OTMSDBZUPAUEDD-UHFFFAOYSA-N",
+                    "adsorption": 0.3988,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "ATUOYWHBWRKTHZ-UHFFFAOYSA-N",
+                    "adsorption": 0.9142,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "IJDNQMDRQITEOD-UHFFFAOYSA-N",
+                    "adsorption": 0.9142,
+                    "composition": 0.25
+                }
+            ]
+        },
+        {
+            "pressure": 29884.0,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 0.3414,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "OTMSDBZUPAUEDD-UHFFFAOYSA-N",
+                    "adsorption": 0.7041,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "ATUOYWHBWRKTHZ-UHFFFAOYSA-N",
+                    "adsorption": 0.6401,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "IJDNQMDRQITEOD-UHFFFAOYSA-N",
+                    "adsorption": 0.6401,
+                    "composition": 0.25
+                }
+            ]
+        },
+        {
+            "pressure": 300630.0,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 0.6155,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "OTMSDBZUPAUEDD-UHFFFAOYSA-N",
+                    "adsorption": 0.9848,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "ATUOYWHBWRKTHZ-UHFFFAOYSA-N",
+                    "adsorption": 0.4054,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "IJDNQMDRQITEOD-UHFFFAOYSA-N",
+                    "adsorption": 0.4054,
+                    "composition": 0.25
+                }
+            ]
+        },
+        {
+            "pressure": 3006300.0,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 0.7057,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "OTMSDBZUPAUEDD-UHFFFAOYSA-N",
+                    "adsorption": 1.0668,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "ATUOYWHBWRKTHZ-UHFFFAOYSA-N",
+                    "adsorption": 0.3283,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "IJDNQMDRQITEOD-UHFFFAOYSA-N",
+                    "adsorption": 0.3283,
+                    "composition": 0.25
+                }
+            ]
+        },
+        {
+            "pressure": 30063000.0,
+            "species_data": [
+                {
+                    "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    "adsorption": 0.9552,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "OTMSDBZUPAUEDD-UHFFFAOYSA-N",
+                    "adsorption": 1.1358,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "ATUOYWHBWRKTHZ-UHFFFAOYSA-N",
+                    "adsorption": 0.2347,
+                    "composition": 0.25
+                },
+                {
+                    "InChIKey": "IJDNQMDRQITEOD-UHFFFAOYSA-N",
+                    "adsorption": 0.2347,
+                    "composition": 0.25
+                }
+            ]
+        }
+    ],
+    "measurement_type": "sim",
+    "pressureUnits": "bar",
+    "temperature": 300
+}

--- a/tests/static/quaternary_single_measured.json
+++ b/tests/static/quaternary_single_measured.json
@@ -1,0 +1,138 @@
+{
+    "DOI": "10.1021/la034766z",
+    "adsorbates": [
+        {
+            "InChIKey": "ATUOYWHBWRKTHZ-UHFFFAOYSA-N",
+            "name": "N-propane"
+        },
+        {
+            "InChIKey": "IJDNQMDRQITEOD-UHFFFAOYSA-N",
+            "name": "N-Butane"
+        },
+        {
+            "InChIKey": "OTMSDBZUPAUEDD-UHFFFAOYSA-N",
+            "name": "Ethane"
+        },
+        {
+            "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+            "name": "Methane"
+        }
+    ],
+    "adsorbent": {
+        "hashkey": "NIST-MATDB-b2476664ad65cd2d2dbd01ea30f8138f",
+        "name": "Silicalite ISV"
+    },
+    "adsorptionUnits": "mmol/g",
+    "articleSource": "Figure 11",
+    "category": "sim",
+    "compositionType": "molefraction",
+    "concentrationUnits": "",
+    "date": "2017-06-30",
+    "digitizer": "John Luo",
+    "filename": "10.1021la034766z.Isotherm15",
+    "isotherm_data": [
+        {
+            "pressure": 3.45,
+            "species_data": [
+                {
+                    "InChIKey": "IJDNQMDRQITEOD-UHFFFAOYSA-N",
+                    "adsorption": 0.97905,
+                    "composition": 0.04863
+                }
+            ],
+            "total_adsorption": 0.97905
+        },
+        {
+            "pressure": 3.45,
+            "species_data": [
+                {
+                    "InChIKey": "IJDNQMDRQITEOD-UHFFFAOYSA-N",
+                    "adsorption": 1.31048,
+                    "composition": 0.09915
+                }
+            ],
+            "total_adsorption": 1.31048
+        },
+        {
+            "pressure": 3.45,
+            "species_data": [
+                {
+                    "InChIKey": "IJDNQMDRQITEOD-UHFFFAOYSA-N",
+                    "adsorption": 1.49714,
+                    "composition": 0.148
+                }
+            ],
+            "total_adsorption": 1.49714
+        },
+        {
+            "pressure": 3.45,
+            "species_data": [
+                {
+                    "InChIKey": "IJDNQMDRQITEOD-UHFFFAOYSA-N",
+                    "adsorption": 1.60381,
+                    "composition": 0.19864
+                }
+            ],
+            "total_adsorption": 1.60381
+        },
+        {
+            "pressure": 3.45,
+            "species_data": [
+                {
+                    "InChIKey": "IJDNQMDRQITEOD-UHFFFAOYSA-N",
+                    "adsorption": 1.68762,
+                    "composition": 0.2493
+                }
+            ],
+            "total_adsorption": 1.68762
+        },
+        {
+            "pressure": 3.45,
+            "species_data": [
+                {
+                    "InChIKey": "IJDNQMDRQITEOD-UHFFFAOYSA-N",
+                    "adsorption": 1.74476,
+                    "composition": 0.29909
+                }
+            ],
+            "total_adsorption": 1.74476
+        },
+        {
+            "pressure": 3.45,
+            "species_data": [
+                {
+                    "InChIKey": "IJDNQMDRQITEOD-UHFFFAOYSA-N",
+                    "adsorption": 1.7981,
+                    "composition": 0.34889
+                }
+            ],
+            "total_adsorption": 1.7981
+        },
+        {
+            "pressure": 3.45,
+            "species_data": [
+                {
+                    "InChIKey": "IJDNQMDRQITEOD-UHFFFAOYSA-N",
+                    "adsorption": 1.82095,
+                    "composition": 0.39783
+                }
+            ],
+            "total_adsorption": 1.82095
+        },
+        {
+            "pressure": 3.45,
+            "species_data": [
+                {
+                    "InChIKey": "IJDNQMDRQITEOD-UHFFFAOYSA-N",
+                    "adsorption": 1.85143,
+                    "composition": 0.44851
+                }
+            ],
+            "total_adsorption": 1.85143
+        }
+    ],
+    "isotherm_type": "",
+    "pressureUnits": "bar",
+    "tabular_data": 0,
+    "temperature": 300
+}

--- a/tests/static/relative_isotherm.json
+++ b/tests/static/relative_isotherm.json
@@ -1,0 +1,1106 @@
+{
+    "DOI": "10.1007/s10450-020-00253-0",
+    "adsorbates": [
+        {
+            "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+            "name": "Argon"
+        }
+    ],
+    "adsorbent": {
+        "hashkey": "NIST-MATDB-898edd41ca15e03f0e003dd2448f1e5d",
+        "name": "NIST RM-8850"
+    },
+    "adsorptionUnits": "cm3(STP)/g",
+    "articleSource": "Figure S1",
+    "compositionType": "molefraction",
+    "concentrationUnits": "",
+    "date": "2020-09-08",
+    "digitizer": "NIST FACT Lab",
+    "filename": "10.1007s10450-020-00253-0.Argon.Isotherm1",
+    "isotherm_data": [
+        {
+            "pressure": 6.53771e-07,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 0.0345,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 0.0345
+        },
+        {
+            "pressure": 1.93509e-06,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 0.3145,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 0.3145
+        },
+        {
+            "pressure": 4.49258e-06,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 0.5951,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 0.5951
+        },
+        {
+            "pressure": 6.092469999999999e-06,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 0.804,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 0.804
+        },
+        {
+            "pressure": 6.938510000000001e-06,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 0.9269,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 0.9269
+        },
+        {
+            "pressure": 1.97872e-05,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 2.0751,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 2.0751
+        },
+        {
+            "pressure": 2.77132e-05,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 2.6959,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 2.6959
+        },
+        {
+            "pressure": 3.6161599999999996e-05,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 3.3192,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 3.3192
+        },
+        {
+            "pressure": 4.4111000000000005e-05,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 3.918,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 3.918
+        },
+        {
+            "pressure": 6.0210699999999996e-05,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 5.0862,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 5.0862
+        },
+        {
+            "pressure": 6.775729999999999e-05,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 5.6227,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 5.6227
+        },
+        {
+            "pressure": 7.49091e-05,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 6.1471,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 6.1471
+        },
+        {
+            "pressure": 8.98222e-05,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 7.2506,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 7.2506
+        },
+        {
+            "pressure": 9.6738e-05,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 7.7571,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 7.7571
+        },
+        {
+            "pressure": 0.0002074,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 16.828,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 16.828
+        },
+        {
+            "pressure": 0.000308967,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 27.2196,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 27.2196
+        },
+        {
+            "pressure": 0.00040294,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 38.5773,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 38.5773
+        },
+        {
+            "pressure": 0.000500916,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 53.623000000000005,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 53.623000000000005
+        },
+        {
+            "pressure": 0.000602553,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 72.595,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 72.595
+        },
+        {
+            "pressure": 0.0007025689999999999,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 93.1222,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 93.1222
+        },
+        {
+            "pressure": 0.000802985,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 111.8912,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 111.8912
+        },
+        {
+            "pressure": 0.0009008610000000001,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 125.9135,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 125.9135
+        },
+        {
+            "pressure": 0.00100391,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 136.4424,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 136.4424
+        },
+        {
+            "pressure": 0.00204641,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 177.6426,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 177.6426
+        },
+        {
+            "pressure": 0.00311852,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 190.2539,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 190.2539
+        },
+        {
+            "pressure": 0.00403785,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 195.8704,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 195.8704
+        },
+        {
+            "pressure": 0.00501793,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 199.8118,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 199.8118
+        },
+        {
+            "pressure": 0.00603248,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 202.71099999999998,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 202.71099999999998
+        },
+        {
+            "pressure": 0.00701752,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 204.8615,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 204.8615
+        },
+        {
+            "pressure": 0.00802981,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 206.6507,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 206.6507
+        },
+        {
+            "pressure": 0.00903946,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 208.1423,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 208.1423
+        },
+        {
+            "pressure": 0.010062100000000001,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 209.4295,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 209.4295
+        },
+        {
+            "pressure": 0.0203025,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 216.7183,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 216.7183
+        },
+        {
+            "pressure": 0.026360200000000004,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 219.0593,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 219.0593
+        },
+        {
+            "pressure": 0.030273400000000002,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 220.2559,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 220.2559
+        },
+        {
+            "pressure": 0.0412514,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 222.8596,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 222.8596
+        },
+        {
+            "pressure": 0.0499341,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 224.34,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 224.34
+        },
+        {
+            "pressure": 0.06006759999999999,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 225.72799999999998,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 225.72799999999998
+        },
+        {
+            "pressure": 0.0704909,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 226.8851,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 226.8851
+        },
+        {
+            "pressure": 0.07635,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 227.4669,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 227.4669
+        },
+        {
+            "pressure": 0.0814328,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 227.9186,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 227.9186
+        },
+        {
+            "pressure": 0.0911722,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 228.6943,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 228.6943
+        },
+        {
+            "pressure": 0.101338,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 229.3924,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 229.3924
+        },
+        {
+            "pressure": 0.125686,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 230.8425,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 230.8425
+        },
+        {
+            "pressure": 0.149807,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 232.0473,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 232.0473
+        },
+        {
+            "pressure": 0.175091,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 233.1259,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 233.1259
+        },
+        {
+            "pressure": 0.200427,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 234.0593,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 234.0593
+        },
+        {
+            "pressure": 0.225507,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 234.8811,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 234.8811
+        },
+        {
+            "pressure": 0.250706,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 235.6442,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 235.6442
+        },
+        {
+            "pressure": 0.27569099999999996,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 236.3558,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 236.3558
+        },
+        {
+            "pressure": 0.301014,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 237.0006,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 237.0006
+        },
+        {
+            "pressure": 0.325841,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 237.615,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 237.615
+        },
+        {
+            "pressure": 0.351013,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 238.1877,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 238.1877
+        },
+        {
+            "pressure": 0.375775,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 238.7474,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 238.7474
+        },
+        {
+            "pressure": 0.401069,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 239.2925,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 239.2925
+        },
+        {
+            "pressure": 0.426034,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 239.8118,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 239.8118
+        },
+        {
+            "pressure": 0.45088500000000004,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 240.3092,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 240.3092
+        },
+        {
+            "pressure": 0.476243,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 240.7902,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 240.7902
+        },
+        {
+            "pressure": 0.5008640000000001,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 241.2776,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 241.2776
+        },
+        {
+            "pressure": 0.526749,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 241.7494,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 241.7494
+        },
+        {
+            "pressure": 0.550313,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 242.2891,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 242.2891
+        },
+        {
+            "pressure": 0.5754630000000001,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 242.815,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 242.815
+        },
+        {
+            "pressure": 0.601171,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 243.308,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 243.308
+        },
+        {
+            "pressure": 0.625961,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 243.7822,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 243.7822
+        },
+        {
+            "pressure": 0.651396,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 244.2226,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 244.2226
+        },
+        {
+            "pressure": 0.675941,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 244.735,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 244.735
+        },
+        {
+            "pressure": 0.7012970000000001,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 245.2001,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 245.2001
+        },
+        {
+            "pressure": 0.726006,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 245.6807,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 245.6807
+        },
+        {
+            "pressure": 0.751408,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 246.1625,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 246.1625
+        },
+        {
+            "pressure": 0.77563,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 246.6876,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 246.6876
+        },
+        {
+            "pressure": 0.8009970000000001,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 247.203,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 247.203
+        },
+        {
+            "pressure": 0.826348,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 247.8186,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 247.8186
+        },
+        {
+            "pressure": 0.850459,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 248.3849,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 248.3849
+        },
+        {
+            "pressure": 0.8760129999999999,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 249.0667,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 249.0667
+        },
+        {
+            "pressure": 0.899552,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 249.9287,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 249.9287
+        },
+        {
+            "pressure": 0.92535,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 251.0305,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 251.0305
+        },
+        {
+            "pressure": 0.949622,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 252.5851,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 252.5851
+        },
+        {
+            "pressure": 0.973814,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 256.185,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 256.185
+        },
+        {
+            "pressure": 0.995025,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 274.2511,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 274.2511
+        },
+        {
+            "pressure": 0.946775,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 253.7023,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 253.7023
+        },
+        {
+            "pressure": 0.898761,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 250.8904,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 250.8904
+        },
+        {
+            "pressure": 0.8511110000000001,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 249.4186,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 249.4186
+        },
+        {
+            "pressure": 0.8001159999999999,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 248.1937,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 248.1937
+        },
+        {
+            "pressure": 0.750071,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 247.1461,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 247.1461
+        },
+        {
+            "pressure": 0.699919,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 246.1356,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 246.1356
+        },
+        {
+            "pressure": 0.650397,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 245.1666,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 245.1666
+        },
+        {
+            "pressure": 0.599995,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 244.1857,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 244.1857
+        },
+        {
+            "pressure": 0.549796,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 243.2479,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 243.2479
+        },
+        {
+            "pressure": 0.500237,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 242.2733,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 242.2733
+        },
+        {
+            "pressure": 0.45027,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 241.0803,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 241.0803
+        },
+        {
+            "pressure": 0.40021,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 239.8172,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 239.8172
+        },
+        {
+            "pressure": 0.350302,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 238.6762,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 238.6762
+        },
+        {
+            "pressure": 0.30019,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 237.4537,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 237.4537
+        },
+        {
+            "pressure": 0.250377,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 236.1096,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 236.1096
+        },
+        {
+            "pressure": 0.200879,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 234.52200000000002,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 234.52200000000002
+        },
+        {
+            "pressure": 0.148757,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 232.415,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 232.415
+        },
+        {
+            "pressure": 0.09944639999999999,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 229.7168,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 229.7168
+        },
+        {
+            "pressure": 0.0496502,
+            "species_data": [
+                {
+                    "InChIKey": "XKRFYHLGVUSROY-UHFFFAOYSA-N",
+                    "adsorption": 224.7216,
+                    "composition": "1.0"
+                }
+            ],
+            "total_adsorption": 224.7216
+        }
+    ],
+    "isotherm_type": "excess",
+    "category": "exp",
+    "pressureUnits": "RELATIVE",
+    "saturationPressure": 1.01325,
+    "tabular_data": true,
+    "temperature": 87
+}


### PR DESCRIPTION
…_isotherm_json function

Candidates for tests:
experimental_withkeys.json:  single-component isotherm with InChIKeys and hashkeys specified
experimental_withnames.json:  single-component isotherm with adsorbate and adsorbent names specified, I used this to confirm the name->key reverse lookup
concentration.json: single-component isotherm, with concentration specified.
quaternary.json: full 4-component isotherm, with isotherms for each species
quaternary_single_measured.json: four adsorbates specified in "adsorbates" key, but isotherm_data only contains one isotherm.
relative_isotherm.json: single-component isotherm with RELATIVE units